### PR TITLE
Omid/add powerdraw support

### DIFF
--- a/artifacts/usr/local/bin/gpumetrics.sh
+++ b/artifacts/usr/local/bin/gpumetrics.sh
@@ -8,7 +8,7 @@ GPUMETRICS_LOG="/var/log/gpumetrics/gpumetrics.log"
 LOGGER="/usr/bin/logger -i -t gpumetrics -p local4.info"
 LOGGER_ERR="/usr/bin/logger -i -t gpumetrics -p local4.err"
 
-### GPUMetrics Variables to populate
+# GPUMetrics Variables
 GPUDriverVersion=""
 GPUInstance=""
 GPUMemPercentUsed=""
@@ -18,93 +18,82 @@ GPUTotalRAM=""
 GPUUsedRAM=""
 GPUUtilPercent=""
 GPUUtilPercentAvg=""
+GPUPowerDraw=""
 ReportTime=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
 ResourceID=""
 TimeGenerated=""
 
-# Check if the effective user ID is 0 (root)
 if [ "$EUID" -ne 0 ]; then
   >&2 echo "This script must be run as root"
   exit 1
 fi
 
 if ! command -v curl &> /dev/null; then
-  write_error "curl command not found"
+  echo "curl command not found" | $LOGGER_ERR
   exit 1
 fi
 
 is_cloud_environment() {
-    timeout 1 bash -c '< /dev/tcp/169.254.169.254/80' > /dev/null 2>&1
-    return $?
+  timeout 1 bash -c '< /dev/tcp/169.254.169.254/80' > /dev/null 2>&1
+  return $?
 }
 
 trim() {
-    local var="$*"
-    # remove leading whitespace characters
-    var="${var#"${var%%[![:space:]]*}"}"
-    # remove trailing whitespace characters
-    var="${var%"${var##*[![:space:]]}"}"
-    printf '%s' "$var"
+  local var="$*"
+  var="${var#"${var%%[![:space:]]*}"}"
+  var="${var%"${var##*[![:space:]]}"}"
+  printf '%s' "$var"
 }
 
-function write_error () {
-  echo $1 | $LOGGER_ERR
+write_error () {
+  echo "$1" | $LOGGER_ERR
 }
 
-function write_log {
-  echo "{\"ResourceID\":\"$ResourceID\",\"GPUName\":\"$GPUName\",\"GPUTotalRAM\":$GPUTotalRAM,\"GPUUsedRAM\":$GPUUsedRAM,\"GPUMemPercentUsed\":$GPUMemPercentUsed,\"GPUUtilPercent\":$GPUUtilPercent,\"GPUUtilPercentAvg\":$GPUUtilPercentAvg,\"GPUTemperature\":$GPUTemperature,\"GPUInstance\":$GPUInstance,\"GPUDriverVersion\":\"$GPUDriverVersion\",\"ReportTime\":\"$ReportTime\"}" | $LOGGER
+write_log() {
+  echo "{\"ResourceID\":\"$ResourceID\",\"GPUName\":\"$GPUName\",\"GPUTotalRAM\":$GPUTotalRAM,\"GPUUsedRAM\":$GPUUsedRAM,\"GPUMemPercentUsed\":$GPUMemPercentUsed,\"GPUUtilPercent\":$GPUUtilPercent,\"GPUUtilPercentAvg\":$GPUUtilPercentAvg,\"GPUTemperature\":$GPUTemperature,\"GPUPowerDraw\":$GPUPowerDraw,\"GPUInstance\":$GPUInstance,\"GPUDriverVersion\":\"$GPUDriverVersion\",\"ReportTime\":\"$ReportTime\"}" | $LOGGER
 }
 
-function get_nvidia {
-  output=$(timeout $TIMEOUT $NVIDIA_SMI --query-gpu=driver_version,index,utilization.memory,name,temperature.gpu,memory.total,memory.used,utilization.gpu,utilization.gpu --format=csv,noheader,nounits)
+get_nvidia() {
+  output=$(timeout $TIMEOUT $NVIDIA_SMI --query-gpu=driver_version,index,utilization.memory,name,temperature.gpu,memory.total,memory.used,utilization.gpu,utilization.gpu,power.draw --format=csv,noheader,nounits)
   if [ $? -ne 0 ]; then
     write_error "nvidia-smi command failed - $output"
     exit 1
   fi
 
-  echo "$output" | while IFS=, read -r GPUDriverVersion GPUInstance GPUMemPercentUsed GPUName GPUTemperature GPUTotalRAM GPUUsedRAM GPUUtilPercent GPUUtilPercentAvg; do
-    GPUName=$(trim "${GPUName}")
-    GPUTotalRAM=$(trim "${GPUTotalRAM}")
-    GPUUsedRAM=$(trim "${GPUUsedRAM}")
-    GPUMemPercentUsed=$(trim "${GPUMemPercentUsed}")
-    GPUUtilPercent=$(trim "${GPUUtilPercent}")
-    GPUUtilPercentAvg=$(trim "${GPUUtilPercentAvg}")
-    GPUTemperature=$(trim "${GPUTemperature}")
-    GPUInstance=$(trim "${GPUInstance}")
+  echo "$output" | while IFS=, read -r GPUDriverVersion GPUInstance GPUMemPercentUsed GPUName GPUTemperature GPUTotalRAM GPUUsedRAM GPUUtilPercent GPUUtilPercentAvg GPUPowerDraw; do
+    GPUName=$(trim "$GPUName")
+    GPUTotalRAM=$(trim "$GPUTotalRAM")
+    GPUUsedRAM=$(trim "$GPUUsedRAM")
+    GPUMemPercentUsed=$(trim "$GPUMemPercentUsed")
+    GPUUtilPercent=$(trim "$GPUUtilPercent")
+    GPUUtilPercentAvg=$(trim "$GPUUtilPercentAvg")
+    GPUTemperature=$(trim "$GPUTemperature")
+    GPUPowerDraw=$(trim "$GPUPowerDraw")
+    GPUInstance=$(trim "$GPUInstance")
     write_log
   done
 }
 
-function get_amd {
-  AMDCARD=""
-  AMDSensorTemp=""
-  AMDMemTemp=""
-  AMDGPUUse=""
-  AMDGFXActivity=""
-  AMDVRAMTotalMem=""
-  AMDVRAMTotalUsedMem=""
-  AMDCardSeries=""
-  AMDCardModel=""
-  AMDCardVendor=""
-  AMDCardSKU=""
-  AMDSubsystemID=""
-  AMDDeviceRev=""
-  AMDNodeId=""
-  AMDGUID=""
-  AMDGFXVersion=""
-  output=$(timeout $TIMEOUT $ROCM_SMI --showmeminfo=vram --showproductname --showtemp --showuse --csv)
+get_amd() {
+  output=$(timeout $TIMEOUT $ROCM_SMI --showmeminfo=vram --showproductname --showtemp --showuse --showpower --csv)
   if [ $? -ne 0 ]; then
     write_error "rocm-smi command failed - $output"
     exit 1
   fi
 
-  echo "$output" | while IFS=, read -r AMDCARD AMDSensorTemp AMDMemTemp AMDGPUUse AMDGFXActivity AMDVRAMTotalMem AMDVRAMTotalUsedMem AMDCardSeries AMDCardModel AMDCardVendor AMDCardSKU AMDSubsystemID AMDDeviceRev AMDNodeId AMDGUID AMDGFXVersion; do
-    # Skip if we have the header, or an empty value
-    if [[ "$AMDCARD" == "device" || "$AMDCARD" == "" ]]; then
+  echo "$output" | awk -F',' 'NF && NR==1 {
+    print $0
+  }
+  NF && NR>1 {
+    $7 = sprintf("%.2f", $7 / 1024 / 1024)
+    $8 = sprintf("%.2f", $8 / 1024 / 1024)
+    print $1","$2","$3","$4","$5","$6","$7","$8","$9","$10","$11","$12","$13","$14","$15","$16","$17
+  }' | while IFS=, read -r AMDCARD AMDSensorTemp AMDMemTemp AMDPower AMDGPUUse AMDGFXActivity AMDVRAMTotalMem AMDVRAMTotalUsedMem AMDCardSeries AMDCardModel AMDCardVendor AMDCardSKU AMDSubsystemID AMDDeviceRev AMDNodeId AMDGUID AMDGFXVersion; do
+    if [[ "$AMDCARD" == "device" || -z "$AMDCARD" ]]; then
       continue
     fi
     GPUDriverVersion=$AMDGFXVersion
-    GPUInstance=$(echo $AMDCARD | tr -d "card")
+    GPUInstance=$(echo "$AMDCARD" | tr -d "card")
     GPUName="AMD $AMDCardSeries"
     GPUTemperature=$(printf "%.0f" "$AMDSensorTemp")
     GPUTotalRAM=$AMDVRAMTotalMem
@@ -112,35 +101,36 @@ function get_amd {
     GPUMemPercentUsed=$(awk "BEGIN {printf \"%d\", ($GPUUsedRAM/$GPUTotalRAM)*100}")
     GPUUtilPercent=$AMDGPUUse
     GPUUtilPercentAvg=$AMDGPUUse
+    GPUPowerDraw=$(printf "%.1f" "$AMDPower")
     write_log
   done
 }
 
+# Resource ID detection
 if is_cloud_environment; then
   ResourceID=$(curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance/compute?api-version=2021-02-01" | sed -n 's/.*"resourceId":"\([^"]*\)".*/\1/p')
-# Otherwise see if we're an Arc host
-elif $(timeout 1 bash -c '< /dev/tcp/127.0.0.1/40342' > /dev/null 2>&1 ); then
+elif timeout 1 bash -c '< /dev/tcp/127.0.0.1/40342' > /dev/null 2>&1; then
   export IMDS_ENDPOINT="http://localhost:40342"
   export IDENTITY_ENDPOINT="http://localhost:40342/metadata/identity/oauth2/token"
-  ResourceID=$(curl -s -D - -H Metadata:true "http://127.0.0.1:40342/metadata/instance/compute?api-version=2020-06-01"|sed -n 's/.*"resourceId":"\([^"]*\)".*/\1/p')
+  ResourceID=$(curl -s -D - -H Metadata:true "http://127.0.0.1:40342/metadata/instance/compute?api-version=2020-06-01" | sed -n 's/.*"resourceId":"\([^"]*\)".*/\1/p')
 else
   write_error "Failed to determine if we're an Arc host or not. Unable to determine ResourceId. Exiting."
   exit 1
 fi
 
-if [ -x $NVIDIA_SMI ];then
+# Detect GPU type
+if [ -x $NVIDIA_SMI ]; then
   GPU_TYPE="NVIDIA"
-elif [ -x $ROCM_SMI ];then
+elif [ -x $ROCM_SMI ]; then
   GPU_TYPE="AMD"
 else
   write_error "No valid GPU tools found"
   exit 1
 fi
 
-if [ "$GPU_TYPE" = "NVIDIA" ];then
+# Collect metrics
+if [ "$GPU_TYPE" = "NVIDIA" ]; then
   get_nvidia
-fi
-
-if [ "$GPU_TYPE" = "AMD" ];then
+elif [ "$GPU_TYPE" = "AMD" ]; then
   get_amd
 fi

--- a/artifacts/usr/local/bin/gpumetrics.sh
+++ b/artifacts/usr/local/bin/gpumetrics.sh
@@ -81,14 +81,16 @@ get_amd() {
     exit 1
   fi
 
-  echo "$output" | awk -F',' 'NF && NR==1 {
-    print $0
+  echo "$output" | awk -F',' '
+  NR==1 {
+    next
   }
-  NF && NR>1 {
+  /^card/ {
     $7 = sprintf("%.2f", $7 / 1024 / 1024)
     $8 = sprintf("%.2f", $8 / 1024 / 1024)
     print $1","$2","$3","$4","$5","$6","$7","$8","$9","$10","$11","$12","$13","$14","$15","$16","$17
   }' | while IFS=, read -r AMDCARD AMDSensorTemp AMDMemTemp AMDPower AMDGPUUse AMDGFXActivity AMDVRAMTotalMem AMDVRAMTotalUsedMem AMDCardSeries AMDCardModel AMDCardVendor AMDCardSKU AMDSubsystemID AMDDeviceRev AMDNodeId AMDGUID AMDGFXVersion; do
+
     if [[ "$AMDCARD" == "device" || -z "$AMDCARD" ]]; then
       continue
     fi


### PR DESCRIPTION
Made some changes top the script to support power draw logs for both AMD and NVIDIA plus converting GPU RAM utilization from using bytes to MiB and some changes based on copilot suggestions to make the script better. 

This has been tested on both AMD and NVIDIA and works as expected

Nvidia logs after the changes: 
`
025-07-15T10:06:49.384989-07:00 GCRSANDBOX300 gpumetrics[1478459]: {"ResourceID":"/subscriptions/46e0b8e9-eb7f-4bbf-af34-a502c2d310f7/resourceGroups/GPU-Sandbox/providers/Microsoft.HybridCompute/machines/GCRSANDBOX300","GPUName":"NVIDIA RTX A6000","GPUTotalRAM":46068,"GPUUsedRAM":1,"GPUMemPercentUsed":0,"GPUUtilPercent":0,"GPUUtilPercentAvg":0,"GPUTemperature":26,"GPUPowerDraw":8.76,"GPUInstance":3,"GPUDriverVersion":"570.158.01","ReportTime":"2025-07-15T17:06:49.000Z"}`

AMD logs after the changes: 


```
Jul 15 17:01:06 GCRAZGDL5005 gpumetrics[2103697]: {"ResourceID":"/subscriptions/46da6261-2167-4e71-8b0d-f4a45215ce61/resourceGroups/GPU-Sandbox4/providers/Microsoft.Compute/virtualMachines/GCRAZGDL5005","GPUName":"AMD 0x74b5","GPUTotalRAM":196048.00,"GPUUsedRAM":286.80,"GPUMemPercentUsed":0,"GPUUtilPercent":0,"GPUUtilPercentAvg":0,"GPUTemperature":37,"GPUPowerDraw":152.0,"GPUInstance":6,"GPUDriverVersion":"gfx942","ReportTime":"2025-07-15T17:01:05.000Z"}
Jul 15 17:01:06 GCRAZGDL5005 gpumetrics[2103705]: {"ResourceID":"/subscriptions/46da6261-2167-4e71-8b0d-f4a45215ce61/resourceGroups/GPU-Sandbox4/providers/Microsoft.Compute/virtualMachines/GCRAZGDL5005","GPUName":"AMD 0x74b5","GPUTotalRAM":196048.00,"GPUUsedRAM":286.80,"GPUMemPercentUsed":0,"GPUUtilPercent":0,"GPUUtilPercentAvg":0,"GPUTemperature":38,"GPUPowerDraw":151.0,"GPUInstance":7,"GPUDriverVersion":"gfx942","ReportTime":"2025-07-15T17:01:05.000Z"}
```
